### PR TITLE
Start tracking dropped messages

### DIFF
--- a/config/mbeans.json
+++ b/config/mbeans.json
@@ -449,6 +449,66 @@
         }
         ],
       "enabled": true
+    },
+    {
+      "mbean": "org.apache.cassandra.metrics:type=DroppedMetrics,scope=MUTATION,name=Dropped",
+      "attributes": [
+       	{
+          "attribute": "MeanRate",
+          "dataType": "double",
+          "metricName": "CASSANDRA_DROPPED_MUTATION_RATE",
+          "key": "",
+          "metricType": "standard",
+          "scale": 1,
+          "enabled": true
+        }
+        ],
+      "enabled": true
+    },
+    {
+      "mbean": "org.apache.cassandra.metrics:type=DroppedMetrics,scope=READ,name=Dropped",
+      "attributes": [
+       	{
+          "attribute": "MeanRate",
+          "dataType": "double",
+          "metricName": "CASSANDRA_DROPPED_READ_RATE",
+          "key": "",
+          "metricType": "standard",
+          "scale": 1,
+          "enabled": true
+        }
+        ],
+      "enabled": true
+    },
+    {
+      "mbean": "org.apache.cassandra.metrics:type=DroppedMetrics,scope=COUNTER_MUTATION,name=Dropped",
+      "attributes": [
+       	{
+          "attribute": "MeanRate",
+          "dataType": "double",
+          "metricName": "CASSANDRA_COUNTER_MUTATION_RATE",
+          "key": "",
+          "metricType": "standard",
+          "scale": 1,
+          "enabled": true
+        }
+        ],
+      "enabled": true
+    },
+    {
+      "mbean": "org.apache.cassandra.metrics:type=DroppedMetrics,scope=HINT,name=Dropped",
+      "attributes": [
+       	{
+          "attribute": "MeanRate",
+          "dataType": "double",
+          "metricName": "CASSANDRA_DROPPED_HINT_RATE",
+          "key": "",
+          "metricType": "standard",
+          "scale": 1,
+          "enabled": true
+        }
+        ],
+      "enabled": true
     }
 
     ]


### PR DESCRIPTION
This PR adds 4 new insights into dropped messages which are early indicators of under-provisioned clusters.

* Mutations.
* Reads.
* Counter Mutations.
* Hints.

Documentation source:
https://github.com/apache/cassandra/blob/trunk/doc/source/operating/metrics.rst#droppedmessage-metrics